### PR TITLE
#142 Implement get command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,12 @@ setup(
     version="2.1.1",
     extras_require={"dev": ["pytest", "pytest-cov", "setuptools", "wheel"]},
     packages=find_packages(),
-    install_requires=["inquirer==2.8.0", "requests", "pytz"],
+    install_requires=[
+        "inquirer==2.8.0",
+        "requests",
+        "pytz",
+        "tabulate==0.8.10",
+    ],
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow
     # pip to create the appropriate form of executable for the target platform.

--- a/src/cli/cliRunner.py
+++ b/src/cli/cliRunner.py
@@ -1,6 +1,5 @@
 import os
 import argparse
-from ast import arg
 import json
 import sys
 import requests
@@ -101,6 +100,7 @@ def parse_change_name(pre_config_id, new_name):
             f"There was an ERROR while changing your Pre Configuration name:  {response_data['error']}"
         )
 
+
 def parse_get_entity(
     entity_name,
     entity_id,
@@ -162,11 +162,6 @@ def parse_get_entity(
         print(json.dumps(data))
 
 
-
-
-
-
-
 def setup():
     parser = argparse.ArgumentParser(
         description="Command line interface for measuresoftgram"
@@ -199,13 +194,12 @@ def setup():
         help="Gets the last record of a specific entity",
     )
 
-
     parser_get_entity.add_argument(
         "entity",
         type=str,
         help=(
-            "The entity to get. Valid values are: " +
-            ", ".join(AVAILABLE_ENTITIES)
+            "The entity to get. Valid values are: "
+            + ", ".join(AVAILABLE_ENTITIES)
         ),
     )
 


### PR DESCRIPTION
## Descrição

Implementação do comando `get` do CLI `measuresoftgram`.
Issue [#142 Obter o valor atual de uma ou mais medidas via CLI](https://github.com/fga-eps-mds/2022-1-MeasureSoftGram-Doc/issues/142)

Esse comando visa obter dados da API do serviço `service`.

Por meio desse comando é possível:
* Especificar o formato de output desejado, sendo eles atualmente `tabular` e `json`, por meio do parâmetro **`--output_format`**
* Especificar a entidade que se deseja obter os valores, sendo elas atualmente `metrics` e measures`, por meio do primeiro parâmetro posicional (`measuresoftgram get metrics` ou `measuresoftgram get measures`)
* Especificar o local onde está hospedado a instância do serviço `service`, sendo por padrão a instância hospedada no heroku, por meio do parâmetro **`--host`**
* Especificar a entidade que se deseja obter o valor atual com o segundo parâmetro posicional (`measuresoftgram get measures <int:id>`)
* Especificar o projeto que essa entidade (medida ou métrica) pertence por meio do parâmetro **`--repository_id`**. Caso o valor não seja passado é procurado o valor na variável de ambiente **`MSG_ORGANIZATION_ID`**, e caso ela não exista é usado o valor **1**.
* Especificar a organização que esse projeto pertence por meio do parâmetro **`--organization_id`**. Caso o valor não seja passado é procurado o valor na variável de ambiente **`MSG_REPOSITORY_ID`**, e caso ela não exista é usado o valor **1**.

## Vídeo do uso do comando get e suas funcionalidades

https://youtu.be/tJ4waG86kYE



## Porque este Pull Request é necessário?
Uma das funcionalidades requisitadas pelo cliente é a utilização do CLI para obter dados do modelo. Dessa forma, por meio do CLI será possível recuperar informações sobre diversas entidades do sistema. Esse PR implementa a obtenção das entidades `metrics` e `measures`

## Critérios de aceitação

1. [x] Obter o valor mais recente de uma determinada medida
2. [x] Obter os valores mais recente de todas as medidas
3. [x] Especificar o formato desejado (json e tabela)
4. [x] Especificar a instância do serviço `service`
5. [x] Especificar o repositório no sistema do MeasureSoftGram
6. [x] Especificar a organização no sistema do MeasureSoftGram

Closes #142