### PR TITLE
#152 Add new command 'import sonarqube <DIR>' to CLI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
         "requests",
         "pytz",
         "tabulate==0.8.10",
+        "termcolor==1.1.0"
     ],
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow

--- a/sonar-output/output_sonar_1.json
+++ b/sonar-output/output_sonar_1.json
@@ -1,0 +1,730 @@
+{
+  "paging": {
+    "pageIndex": 1,
+    "pageSize": 500,
+    "total": 17
+  },
+  "baseComponent": {
+    "id": "AX9FgyLHNIj_v_uQK41e",
+    "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI",
+    "name": "2021-2-MeasureSoftGram-CLI",
+    "qualifier": "TRK",
+    "measures": [
+      {
+        "metric": "duplicated_lines_density",
+        "value": "0.0",
+        "bestValue": "true"
+      },
+      {
+        "metric": "functions",
+        "value": "17"
+      },
+      {
+        "metric": "test_execution_time",
+        "value": "534"
+      },
+      {
+        "metric": "test_failures",
+        "value": "0",
+        "bestValue": "true"
+      },
+      {
+        "metric": "test_errors",
+        "value": "0",
+        "bestValue": "true"
+      },
+      {
+        "metric": "security_rating",
+        "value": "1.0",
+        "bestValue": "true"
+      },
+      {
+        "metric": "tests",
+        "value": "22"
+      },
+      {
+        "metric": "files",
+        "value": "5"
+      },
+      {
+        "metric": "complexity",
+        "value": "64"
+      },
+      {
+        "metric": "ncloc",
+        "value": "331"
+      },
+      {
+        "metric": "coverage",
+        "value": "54.9",
+        "bestValue": "false"
+      },
+      {
+        "metric": "comment_lines_density",
+        "value": "0.6",
+        "bestValue": "false"
+      }
+    ]
+  },
+  "components": [
+    {
+      "id": "AX-gLz5MkGDeAMJwS_V_",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:measuresoftgram/__init__.py",
+      "name": "__init__.py",
+      "qualifier": "FIL",
+      "path": "measuresoftgram/__init__.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "complexity",
+          "value": "0"
+        },
+        {
+          "metric": "functions",
+          "value": "0"
+        },
+        {
+          "metric": "ncloc",
+          "value": "0"
+        },
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "files",
+          "value": "1"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX9GDsKlZuVL7NjXSAZ4",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/__init__.py",
+      "name": "__init__.py",
+      "qualifier": "UTS",
+      "path": "tests/__init__.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WD",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/integration/__init__.py",
+      "name": "__init__.py",
+      "qualifier": "UTS",
+      "path": "tests/integration/__init__.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WH",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/unit/__init__.py",
+      "name": "__init__.py",
+      "qualifier": "UTS",
+      "path": "tests/unit/__init__.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX9Fg6R0WRlRH47OejaP",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:measuresoftgram/cli.py",
+      "name": "cli.py",
+      "qualifier": "FIL",
+      "path": "measuresoftgram/cli.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "complexity",
+          "value": "6"
+        },
+        {
+          "metric": "functions",
+          "value": "4"
+        },
+        {
+          "metric": "ncloc",
+          "value": "50"
+        },
+        {
+          "metric": "coverage",
+          "value": "57.1",
+          "bestValue": "false"
+        },
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "comment_lines_density",
+          "value": "3.8",
+          "bestValue": "false"
+        },
+        {
+          "metric": "files",
+          "value": "1"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WA",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:measuresoftgram/create.py",
+      "name": "create.py",
+      "qualifier": "FIL",
+      "path": "measuresoftgram/create.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "functions",
+          "value": "8"
+        },
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "files",
+          "value": "1"
+        },
+        {
+          "metric": "complexity",
+          "value": "37"
+        },
+        {
+          "metric": "ncloc",
+          "value": "183"
+        },
+        {
+          "metric": "coverage",
+          "value": "47.3",
+          "bestValue": "false"
+        },
+        {
+          "metric": "comment_lines_density",
+          "value": "0.0",
+          "bestValue": "false"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WI",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/unit/create_test.py",
+      "name": "create_test.py",
+      "qualifier": "UTS",
+      "path": "tests/unit/create_test.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_execution_time",
+          "value": "12"
+        },
+        {
+          "metric": "tests",
+          "value": "8"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WE",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/integration",
+      "name": "integration",
+      "qualifier": "DIR",
+      "path": "tests/integration",
+      "measures": [
+        {
+          "metric": "test_execution_time",
+          "value": "509"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "tests",
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_V-",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:measuresoftgram/jsonReader.py",
+      "name": "jsonReader.py",
+      "qualifier": "FIL",
+      "path": "measuresoftgram/jsonReader.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "complexity",
+          "value": "20"
+        },
+        {
+          "metric": "functions",
+          "value": "5"
+        },
+        {
+          "metric": "ncloc",
+          "value": "67"
+        },
+        {
+          "metric": "coverage",
+          "value": "93.0",
+          "bestValue": "false"
+        },
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "comment_lines_density",
+          "value": "0.0",
+          "bestValue": "false"
+        },
+        {
+          "metric": "files",
+          "value": "1"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX9Fg6R0WRlRH47OejaQ",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:measuresoftgram",
+      "name": "measuresoftgram",
+      "qualifier": "DIR",
+      "path": "measuresoftgram",
+      "measures": [
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "functions",
+          "value": "17"
+        },
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "files",
+          "value": "5"
+        },
+        {
+          "metric": "complexity",
+          "value": "64"
+        },
+        {
+          "metric": "ncloc",
+          "value": "331"
+        },
+        {
+          "metric": "coverage",
+          "value": "54.9",
+          "bestValue": "false"
+        },
+        {
+          "metric": "comment_lines_density",
+          "value": "0.6",
+          "bestValue": "false"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WB",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:measuresoftgram/parser.py",
+      "name": "parser.py",
+      "qualifier": "FIL",
+      "path": "measuresoftgram/parser.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "complexity",
+          "value": "1"
+        },
+        {
+          "metric": "functions",
+          "value": "0"
+        },
+        {
+          "metric": "ncloc",
+          "value": "31"
+        },
+        {
+          "metric": "coverage",
+          "value": "0.0",
+          "bestValue": "false"
+        },
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "comment_lines_density",
+          "value": "0.0",
+          "bestValue": "false"
+        },
+        {
+          "metric": "files",
+          "value": "1"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WF",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/utils/sonar.json",
+      "name": "sonar.json",
+      "qualifier": "UTS",
+      "path": "tests/utils/sonar.json",
+      "language": "json",
+      "measures": [
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WC",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/integration/test_help.py",
+      "name": "test_help.py",
+      "qualifier": "UTS",
+      "path": "tests/integration/test_help.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_execution_time",
+          "value": "509"
+        },
+        {
+          "metric": "tests",
+          "value": "1"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WJ",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/unit/test_jsonReader.py",
+      "name": "test_jsonReader.py",
+      "qualifier": "UTS",
+      "path": "tests/unit/test_jsonReader.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_execution_time",
+          "value": "13"
+        },
+        {
+          "metric": "tests",
+          "value": "13"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX9GDsKlZuVL7NjXSAZ5",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests",
+      "name": "tests",
+      "qualifier": "DIR",
+      "path": "tests",
+      "measures": [
+        {
+          "metric": "test_execution_time",
+          "value": "534"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "tests",
+          "value": "22"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WK",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/unit",
+      "name": "unit",
+      "qualifier": "DIR",
+      "path": "tests/unit",
+      "measures": [
+        {
+          "metric": "test_execution_time",
+          "value": "25"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "tests",
+          "value": "21"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WG",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/utils",
+      "name": "utils",
+      "qualifier": "DIR",
+      "path": "tests/utils",
+      "measures": [
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        }
+      ]
+    }
+  ]
+}

--- a/sonar-output/output_sonar_2.json
+++ b/sonar-output/output_sonar_2.json
@@ -1,0 +1,730 @@
+{
+  "paging": {
+    "pageIndex": 1,
+    "pageSize": 500,
+    "total": 17
+  },
+  "baseComponent": {
+    "id": "AX9FgyLHNIj_v_uQK41e",
+    "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI",
+    "name": "2021-2-MeasureSoftGram-CLI",
+    "qualifier": "TRK",
+    "measures": [
+      {
+        "metric": "duplicated_lines_density",
+        "value": "0.0",
+        "bestValue": "true"
+      },
+      {
+        "metric": "functions",
+        "value": "17"
+      },
+      {
+        "metric": "test_execution_time",
+        "value": "534"
+      },
+      {
+        "metric": "test_failures",
+        "value": "0",
+        "bestValue": "true"
+      },
+      {
+        "metric": "test_errors",
+        "value": "0",
+        "bestValue": "true"
+      },
+      {
+        "metric": "security_rating",
+        "value": "1.0",
+        "bestValue": "true"
+      },
+      {
+        "metric": "tests",
+        "value": "22"
+      },
+      {
+        "metric": "files",
+        "value": "5"
+      },
+      {
+        "metric": "complexity",
+        "value": "64"
+      },
+      {
+        "metric": "ncloc",
+        "value": "331"
+      },
+      {
+        "metric": "coverage",
+        "value": "54.9",
+        "bestValue": "false"
+      },
+      {
+        "metric": "comment_lines_density",
+        "value": "0.6",
+        "bestValue": "false"
+      }
+    ]
+  },
+  "components": [
+    {
+      "id": "AX-gLz5MkGDeAMJwS_V_",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:measuresoftgram/__init__.py",
+      "name": "__init__.py",
+      "qualifier": "FIL",
+      "path": "measuresoftgram/__init__.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "complexity",
+          "value": "0"
+        },
+        {
+          "metric": "functions",
+          "value": "0"
+        },
+        {
+          "metric": "ncloc",
+          "value": "0"
+        },
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "files",
+          "value": "1"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX9GDsKlZuVL7NjXSAZ4",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/__init__.py",
+      "name": "__init__.py",
+      "qualifier": "UTS",
+      "path": "tests/__init__.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WD",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/integration/__init__.py",
+      "name": "__init__.py",
+      "qualifier": "UTS",
+      "path": "tests/integration/__init__.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WH",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/unit/__init__.py",
+      "name": "__init__.py",
+      "qualifier": "UTS",
+      "path": "tests/unit/__init__.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX9Fg6R0WRlRH47OejaP",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:measuresoftgram/cli.py",
+      "name": "cli.py",
+      "qualifier": "FIL",
+      "path": "measuresoftgram/cli.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "complexity",
+          "value": "6"
+        },
+        {
+          "metric": "functions",
+          "value": "4"
+        },
+        {
+          "metric": "ncloc",
+          "value": "50"
+        },
+        {
+          "metric": "coverage",
+          "value": "57.1",
+          "bestValue": "false"
+        },
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "comment_lines_density",
+          "value": "3.8",
+          "bestValue": "false"
+        },
+        {
+          "metric": "files",
+          "value": "1"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WA",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:measuresoftgram/create.py",
+      "name": "create.py",
+      "qualifier": "FIL",
+      "path": "measuresoftgram/create.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "functions",
+          "value": "8"
+        },
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "files",
+          "value": "1"
+        },
+        {
+          "metric": "complexity",
+          "value": "37"
+        },
+        {
+          "metric": "ncloc",
+          "value": "183"
+        },
+        {
+          "metric": "coverage",
+          "value": "47.3",
+          "bestValue": "false"
+        },
+        {
+          "metric": "comment_lines_density",
+          "value": "0.0",
+          "bestValue": "false"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WI",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/unit/create_test.py",
+      "name": "create_test.py",
+      "qualifier": "UTS",
+      "path": "tests/unit/create_test.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_execution_time",
+          "value": "12"
+        },
+        {
+          "metric": "tests",
+          "value": "8"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WE",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/integration",
+      "name": "integration",
+      "qualifier": "DIR",
+      "path": "tests/integration",
+      "measures": [
+        {
+          "metric": "test_execution_time",
+          "value": "509"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "tests",
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_V-",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:measuresoftgram/jsonReader.py",
+      "name": "jsonReader.py",
+      "qualifier": "FIL",
+      "path": "measuresoftgram/jsonReader.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "complexity",
+          "value": "20"
+        },
+        {
+          "metric": "functions",
+          "value": "5"
+        },
+        {
+          "metric": "ncloc",
+          "value": "67"
+        },
+        {
+          "metric": "coverage",
+          "value": "93.0",
+          "bestValue": "false"
+        },
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "comment_lines_density",
+          "value": "0.0",
+          "bestValue": "false"
+        },
+        {
+          "metric": "files",
+          "value": "1"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX9Fg6R0WRlRH47OejaQ",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:measuresoftgram",
+      "name": "measuresoftgram",
+      "qualifier": "DIR",
+      "path": "measuresoftgram",
+      "measures": [
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "functions",
+          "value": "17"
+        },
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "files",
+          "value": "5"
+        },
+        {
+          "metric": "complexity",
+          "value": "64"
+        },
+        {
+          "metric": "ncloc",
+          "value": "331"
+        },
+        {
+          "metric": "coverage",
+          "value": "54.9",
+          "bestValue": "false"
+        },
+        {
+          "metric": "comment_lines_density",
+          "value": "0.6",
+          "bestValue": "false"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WB",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:measuresoftgram/parser.py",
+      "name": "parser.py",
+      "qualifier": "FIL",
+      "path": "measuresoftgram/parser.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "complexity",
+          "value": "1"
+        },
+        {
+          "metric": "functions",
+          "value": "0"
+        },
+        {
+          "metric": "ncloc",
+          "value": "31"
+        },
+        {
+          "metric": "coverage",
+          "value": "0.0",
+          "bestValue": "false"
+        },
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "comment_lines_density",
+          "value": "0.0",
+          "bestValue": "false"
+        },
+        {
+          "metric": "files",
+          "value": "1"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WF",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/utils/sonar.json",
+      "name": "sonar.json",
+      "qualifier": "UTS",
+      "path": "tests/utils/sonar.json",
+      "language": "json",
+      "measures": [
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WC",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/integration/test_help.py",
+      "name": "test_help.py",
+      "qualifier": "UTS",
+      "path": "tests/integration/test_help.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_execution_time",
+          "value": "509"
+        },
+        {
+          "metric": "tests",
+          "value": "1"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WJ",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/unit/test_jsonReader.py",
+      "name": "test_jsonReader.py",
+      "qualifier": "UTS",
+      "path": "tests/unit/test_jsonReader.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_execution_time",
+          "value": "13"
+        },
+        {
+          "metric": "tests",
+          "value": "13"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX9GDsKlZuVL7NjXSAZ5",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests",
+      "name": "tests",
+      "qualifier": "DIR",
+      "path": "tests",
+      "measures": [
+        {
+          "metric": "test_execution_time",
+          "value": "534"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "tests",
+          "value": "22"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WK",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/unit",
+      "name": "unit",
+      "qualifier": "DIR",
+      "path": "tests/unit",
+      "measures": [
+        {
+          "metric": "test_execution_time",
+          "value": "25"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "tests",
+          "value": "21"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WG",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/utils",
+      "name": "utils",
+      "qualifier": "DIR",
+      "path": "tests/utils",
+      "measures": [
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        }
+      ]
+    }
+  ]
+}

--- a/sonar-output/output_sonar_3.json
+++ b/sonar-output/output_sonar_3.json
@@ -1,0 +1,730 @@
+{
+  "paging": {
+    "pageIndex": 1,
+    "pageSize": 500,
+    "total": 17
+  },
+  "baseComponent": {
+    "id": "AX9FgyLHNIj_v_uQK41e",
+    "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI",
+    "name": "2021-2-MeasureSoftGram-CLI",
+    "qualifier": "TRK",
+    "measures": [
+      {
+        "metric": "duplicated_lines_density",
+        "value": "0.0",
+        "bestValue": "true"
+      },
+      {
+        "metric": "functions",
+        "value": "17"
+      },
+      {
+        "metric": "test_execution_time",
+        "value": "534"
+      },
+      {
+        "metric": "test_failures",
+        "value": "0",
+        "bestValue": "true"
+      },
+      {
+        "metric": "test_errors",
+        "value": "0",
+        "bestValue": "true"
+      },
+      {
+        "metric": "security_rating",
+        "value": "1.0",
+        "bestValue": "true"
+      },
+      {
+        "metric": "tests",
+        "value": "22"
+      },
+      {
+        "metric": "files",
+        "value": "5"
+      },
+      {
+        "metric": "complexity",
+        "value": "64"
+      },
+      {
+        "metric": "ncloc",
+        "value": "331"
+      },
+      {
+        "metric": "coverage",
+        "value": "54.9",
+        "bestValue": "false"
+      },
+      {
+        "metric": "comment_lines_density",
+        "value": "0.6",
+        "bestValue": "false"
+      }
+    ]
+  },
+  "components": [
+    {
+      "id": "AX-gLz5MkGDeAMJwS_V_",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:measuresoftgram/__init__.py",
+      "name": "__init__.py",
+      "qualifier": "FIL",
+      "path": "measuresoftgram/__init__.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "complexity",
+          "value": "0"
+        },
+        {
+          "metric": "functions",
+          "value": "0"
+        },
+        {
+          "metric": "ncloc",
+          "value": "0"
+        },
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "files",
+          "value": "1"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX9GDsKlZuVL7NjXSAZ4",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/__init__.py",
+      "name": "__init__.py",
+      "qualifier": "UTS",
+      "path": "tests/__init__.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WD",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/integration/__init__.py",
+      "name": "__init__.py",
+      "qualifier": "UTS",
+      "path": "tests/integration/__init__.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WH",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/unit/__init__.py",
+      "name": "__init__.py",
+      "qualifier": "UTS",
+      "path": "tests/unit/__init__.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX9Fg6R0WRlRH47OejaP",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:measuresoftgram/cli.py",
+      "name": "cli.py",
+      "qualifier": "FIL",
+      "path": "measuresoftgram/cli.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "complexity",
+          "value": "6"
+        },
+        {
+          "metric": "functions",
+          "value": "4"
+        },
+        {
+          "metric": "ncloc",
+          "value": "50"
+        },
+        {
+          "metric": "coverage",
+          "value": "57.1",
+          "bestValue": "false"
+        },
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "comment_lines_density",
+          "value": "3.8",
+          "bestValue": "false"
+        },
+        {
+          "metric": "files",
+          "value": "1"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WA",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:measuresoftgram/create.py",
+      "name": "create.py",
+      "qualifier": "FIL",
+      "path": "measuresoftgram/create.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "functions",
+          "value": "8"
+        },
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "files",
+          "value": "1"
+        },
+        {
+          "metric": "complexity",
+          "value": "37"
+        },
+        {
+          "metric": "ncloc",
+          "value": "183"
+        },
+        {
+          "metric": "coverage",
+          "value": "47.3",
+          "bestValue": "false"
+        },
+        {
+          "metric": "comment_lines_density",
+          "value": "0.0",
+          "bestValue": "false"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WI",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/unit/create_test.py",
+      "name": "create_test.py",
+      "qualifier": "UTS",
+      "path": "tests/unit/create_test.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_execution_time",
+          "value": "12"
+        },
+        {
+          "metric": "tests",
+          "value": "8"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WE",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/integration",
+      "name": "integration",
+      "qualifier": "DIR",
+      "path": "tests/integration",
+      "measures": [
+        {
+          "metric": "test_execution_time",
+          "value": "509"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "tests",
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_V-",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:measuresoftgram/jsonReader.py",
+      "name": "jsonReader.py",
+      "qualifier": "FIL",
+      "path": "measuresoftgram/jsonReader.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "complexity",
+          "value": "20"
+        },
+        {
+          "metric": "functions",
+          "value": "5"
+        },
+        {
+          "metric": "ncloc",
+          "value": "67"
+        },
+        {
+          "metric": "coverage",
+          "value": "93.0",
+          "bestValue": "false"
+        },
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "comment_lines_density",
+          "value": "0.0",
+          "bestValue": "false"
+        },
+        {
+          "metric": "files",
+          "value": "1"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX9Fg6R0WRlRH47OejaQ",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:measuresoftgram",
+      "name": "measuresoftgram",
+      "qualifier": "DIR",
+      "path": "measuresoftgram",
+      "measures": [
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "functions",
+          "value": "17"
+        },
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "files",
+          "value": "5"
+        },
+        {
+          "metric": "complexity",
+          "value": "64"
+        },
+        {
+          "metric": "ncloc",
+          "value": "331"
+        },
+        {
+          "metric": "coverage",
+          "value": "54.9",
+          "bestValue": "false"
+        },
+        {
+          "metric": "comment_lines_density",
+          "value": "0.6",
+          "bestValue": "false"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WB",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:measuresoftgram/parser.py",
+      "name": "parser.py",
+      "qualifier": "FIL",
+      "path": "measuresoftgram/parser.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "complexity",
+          "value": "1"
+        },
+        {
+          "metric": "functions",
+          "value": "0"
+        },
+        {
+          "metric": "ncloc",
+          "value": "31"
+        },
+        {
+          "metric": "coverage",
+          "value": "0.0",
+          "bestValue": "false"
+        },
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "comment_lines_density",
+          "value": "0.0",
+          "bestValue": "false"
+        },
+        {
+          "metric": "files",
+          "value": "1"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WF",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/utils/sonar.json",
+      "name": "sonar.json",
+      "qualifier": "UTS",
+      "path": "tests/utils/sonar.json",
+      "language": "json",
+      "measures": [
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WC",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/integration/test_help.py",
+      "name": "test_help.py",
+      "qualifier": "UTS",
+      "path": "tests/integration/test_help.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_execution_time",
+          "value": "509"
+        },
+        {
+          "metric": "tests",
+          "value": "1"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WJ",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/unit/test_jsonReader.py",
+      "name": "test_jsonReader.py",
+      "qualifier": "UTS",
+      "path": "tests/unit/test_jsonReader.py",
+      "language": "py",
+      "measures": [
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_execution_time",
+          "value": "13"
+        },
+        {
+          "metric": "tests",
+          "value": "13"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "duplicated_lines_density",
+          "value": "0.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "AX9GDsKlZuVL7NjXSAZ5",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests",
+      "name": "tests",
+      "qualifier": "DIR",
+      "path": "tests",
+      "measures": [
+        {
+          "metric": "test_execution_time",
+          "value": "534"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "tests",
+          "value": "22"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WK",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/unit",
+      "name": "unit",
+      "qualifier": "DIR",
+      "path": "tests/unit",
+      "measures": [
+        {
+          "metric": "test_execution_time",
+          "value": "25"
+        },
+        {
+          "metric": "test_failures",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "test_errors",
+          "value": "0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        },
+        {
+          "metric": "tests",
+          "value": "21"
+        }
+      ]
+    },
+    {
+      "id": "AX-gLz5MkGDeAMJwS_WG",
+      "key": "fga-eps-mds_2021-2-MeasureSoftGram-CLI:tests/utils",
+      "name": "utils",
+      "qualifier": "DIR",
+      "path": "tests/utils",
+      "measures": [
+        {
+          "metric": "security_rating",
+          "value": "1.0",
+          "bestValue": "true"
+        }
+      ]
+    }
+  ]
+}

--- a/sonar-output/test.c
+++ b/sonar-output/test.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main()
+{
+    printf("Good morning!");
+    return 0;
+}

--- a/sonar-output/test.txt
+++ b/sonar-output/test.txt
@@ -1,0 +1,1 @@
+Teste para erro on import command

--- a/src/cli/cliRunner.py
+++ b/src/cli/cliRunner.py
@@ -17,6 +17,7 @@ from src.cli.create import validate_pre_config_post, pre_config_file_reader
 from src.cli.available import parse_available
 
 BASE_URL = "http://localhost:5000/"
+MSG_SERVICE_HOST = "https://measuresoftgram-service.herokuapp.com/"
 
 AVAILABLE_ENTITIES = [
     "metrics",
@@ -48,8 +49,8 @@ def parse_analysis(id):
     validade_analysis_response(response.status_code, response.json())
 
 
-def parse_import(output_origin, dir_path, id, language_extension):
-    print(output_origin)
+def parse_import(output_origin, dir_path, id, language_extension, host_url):
+    print(output_origin, host_url)
     try:
         components = file_reader(r"{}".format(dir_path))
     except MeasureSoftGramCLIException as error:
@@ -62,7 +63,7 @@ def parse_import(output_origin, dir_path, id, language_extension):
         "language_extension": language_extension,
     }
 
-    response = requests.post(BASE_URL + "import-metrics", json=payload)
+    response = requests.post(host_url + "import-metrics", json=payload)
 
     validate_metrics_post(response.status_code, json.loads(response.text))
 
@@ -203,6 +204,14 @@ def setup():
         help="The source code language extension",
     )
 
+    parser_import.add_argument(
+        "--host",
+        type=str,
+        nargs='?',
+        default=MSG_SERVICE_HOST,
+        help="The host of the service",
+    )
+
     parser_get_entity = subparsers.add_parser(
         "get",
         help="Gets the last record of a specific entity",
@@ -319,7 +328,13 @@ def setup():
         return
 
     elif args.command == "import":
-        parse_import(args.output_origin, args.dir_path, args.id, args.language_extension)
+        parse_import(
+            args.output_origin,
+            args.dir_path,
+            args.id,
+            args.language_extension,
+            args.host
+        )
 
     elif args.command == "create":
         parse_create(args.path)

--- a/src/cli/cliRunner.py
+++ b/src/cli/cliRunner.py
@@ -61,7 +61,7 @@ def parse_import(
 ):
     try:
         components, files = folder_reader(r"{}".format(dir_path))
-    except (MeasureSoftGramCLIException, FileNotFoundError) as error:
+    except (MeasureSoftGramCLIException, FileNotFoundError):
         print("Error: The folder was not found")
         return
 

--- a/src/cli/cliRunner.py
+++ b/src/cli/cliRunner.py
@@ -15,6 +15,7 @@ from src.cli.jsonReader import file_reader, validate_metrics_post
 from src.cli.results import validade_analysis_response
 from src.cli.create import validate_pre_config_post, pre_config_file_reader
 from src.cli.available import parse_available
+from src.cli.utils import check_host_url
 
 BASE_URL = "http://localhost:5000/"
 MSG_SERVICE_HOST = "https://measuresoftgram-service.herokuapp.com/"
@@ -62,6 +63,8 @@ def parse_import(output_origin, dir_path, id, language_extension, host_url):
         "components": components,
         "language_extension": language_extension,
     }
+
+    host_url = check_host_url(host_url)
 
     response = requests.post(host_url + "import-metrics", json=payload)
 
@@ -122,8 +125,7 @@ def parse_get_entity(
         ))
         return
 
-    if not host_url.endswith("/"):
-        host_url += "/"
+    host_url = check_host_url(host_url)
 
     host_url += (
         'api/v1/'

--- a/src/cli/cliRunner.py
+++ b/src/cli/cliRunner.py
@@ -31,6 +31,10 @@ SUPPORTED_FORMATS = [
     "tabular",
 ]
 
+AVAILABLE_IMPORTS = [
+    "sonarqube"
+]
+
 
 def sigint_handler(*_):
     print("\n\nExiting MeasureSoftGram...")
@@ -44,9 +48,10 @@ def parse_analysis(id):
     validade_analysis_response(response.status_code, response.json())
 
 
-def parse_import(file_path, id, language_extension):
+def parse_import(output_origin, dir_path, id, language_extension):
+    print(output_origin)
     try:
-        components = file_reader(r"{}".format(file_path))
+        components = file_reader(r"{}".format(dir_path))
     except MeasureSoftGramCLIException as error:
         print("Error: ", error)
         return
@@ -168,13 +173,22 @@ def setup():
     )
     subparsers = parser.add_subparsers(dest="command", help="sub-command help")
 
-    parser_import = subparsers.add_parser("import", help="Import a metrics file")
+    parser_import = subparsers.add_parser("import", help="Import a folder with metrics")
 
     parser_import.add_argument(
-        "path",
+        "output_origin",
+        type=str,
+        help=(
+            "Import a metrics files from some origin. Valid values are: "
+            + ", ".join(AVAILABLE_IMPORTS)
+        ),
+    )
+
+    parser_import.add_argument(
+        "dir_path",
         type=lambda p: Path(p).absolute(),
         default=Path(__file__).absolute().parent / "data",
-        help="Path to the data directory",
+        help="Path to the directory",
     )
 
     parser_import.add_argument(
@@ -305,7 +319,7 @@ def setup():
         return
 
     elif args.command == "import":
-        parse_import(args.path, args.id, args.language_extension)
+        parse_import(args.output_origin, args.dir_path, args.id, args.language_extension)
 
     elif args.command == "create":
         parse_create(args.path)

--- a/src/cli/cliRunner.py
+++ b/src/cli/cliRunner.py
@@ -61,8 +61,8 @@ def parse_import(
 ):
     try:
         components, files = folder_reader(r"{}".format(dir_path))
-    except MeasureSoftGramCLIException as error:
-        print("Error: ", error)
+    except (MeasureSoftGramCLIException, FileNotFoundError) as error:
+        print("Error: The folder was not found")
         return
 
     payload = {

--- a/src/cli/cliRunner.py
+++ b/src/cli/cliRunner.py
@@ -53,7 +53,6 @@ def parse_analysis(id):
 def parse_import(
     output_origin,
     dir_path,
-    id,
     language_extension,
     host_url,
     organization_id,
@@ -67,7 +66,6 @@ def parse_import(
         return
 
     payload = {
-        "pre_config_id": id,
         "components": [],
         "language_extension": language_extension,
     }
@@ -233,12 +231,6 @@ def setup():
     )
 
     parser_import.add_argument(
-        "id",
-        type=str,
-        help="Pre config ID",
-    )
-
-    parser_import.add_argument(
         "language_extension",
         type=str,
         help="The source code language extension",
@@ -390,7 +382,6 @@ def setup():
         parse_import(
             args.output_origin,
             args.dir_path,
-            args.id,
             args.language_extension,
             args.host,
             args.organization_id,

--- a/src/cli/cliRunner.py
+++ b/src/cli/cliRunner.py
@@ -8,7 +8,6 @@ import signal
 from pathlib import Path
 
 from tabulate import tabulate
-import urllib3
 
 from src.cli.show import parse_show
 from src.cli.list import parse_list
@@ -98,9 +97,7 @@ def parse_import(
             except (
                 requests.RequestException,
                 ConnectionError,
-                ConnectionRefusedError,
                 HTTPError,
-                requests.Timeout,
                 json.decoder.JSONDecodeError
             ):
                 print_status_import_file(

--- a/src/cli/cliRunner.py
+++ b/src/cli/cliRunner.py
@@ -12,7 +12,7 @@ from tabulate import tabulate
 from src.cli.show import parse_show
 from src.cli.list import parse_list
 from src.cli.exceptions import MeasureSoftGramCLIException
-from src.cli.jsonReader import file_reader, folder_reader, validate_metrics_post
+from src.cli.jsonReader import folder_reader, validate_metrics_post
 from src.cli.results import validade_analysis_response
 from src.cli.create import validate_pre_config_post, pre_config_file_reader
 from src.cli.available import parse_available
@@ -89,11 +89,7 @@ def parse_import(
             try:
                 response = requests.post(host_url, json=payload)
 
-                success, message = validate_metrics_post(
-                    response.status_code,
-                    json.loads(response.text),
-                    files[idx]
-                )
+                message = validate_metrics_post(response.status_code)
 
                 print_status_import_file(files[idx], message)
                 break
@@ -102,13 +98,13 @@ def parse_import(
                 HTTPError,
                 requests.Timeout,
                 json.decoder.JSONDecodeError
-            ) as error:
+            ):
                 print_status_import_file(
                     files[idx],
                     "FAIL: Can't connect to host service."
                 )
 
-    print(f'\nAttempt to save all files in the directory finished!')
+    print('\nAttempt to save all files in the directory finished!')
 
 
 def parse_create(file_path):

--- a/src/cli/jsonReader.py
+++ b/src/cli/jsonReader.py
@@ -123,10 +123,9 @@ def check_metrics_values(json_data):
         )
 
 
-def validate_metrics_post(response_status, response, file):
+def validate_metrics_post(response_status):
     if 200 <= response_status <= 299:
-        return True, 'Data sent successfully'
+        return 'Data sent successfully'
 
     return \
-        False, \
         f'FAIL: The host service server returned a {response_status} error. Trying again'

--- a/src/cli/jsonReader.py
+++ b/src/cli/jsonReader.py
@@ -28,19 +28,22 @@ def file_reader(absolute_path):
 
 
 def folder_reader(absolute_path):
-    os.chdir(absolute_path)
-    files_in_dir = os.listdir(absolute_path)
-    components = []
-    files = []
+    try:
+        os.chdir(absolute_path)
+        files_in_dir = os.listdir(absolute_path)
+        components = []
+        files = []
 
-    for file_path in files_in_dir:
-        try:
-            components.append(file_reader(file_path))
-            files.append(f'{absolute_path.split("/")[-1]}/{file_path}')
-        except exceptions.MeasureSoftGramCLIException as error:
-            print("Warning: ", error, f"passing {file_path}...")
+        for file_path in files_in_dir:
+            try:
+                components.append(file_reader(file_path))
+                files.append(f'{absolute_path.split("/")[-1]}/{file_path}')
+            except exceptions.MeasureSoftGramCLIException as error:
+                print("Warning: ", error, f"passing {file_path}...")
 
-    os.chdir('..')
+        os.chdir('..')
+    except FileNotFoundError:
+        raise FileNotFoundError
 
     return components, files
 
@@ -125,7 +128,7 @@ def check_metrics_values(json_data):
 
 def validate_metrics_post(response_status):
     if 200 <= response_status <= 299:
-        return 'Data sent successfully'
+        return 'OK: Data sent successfully'
 
     return \
         f'FAIL: The host service server returned a {response_status} error. Trying again'

--- a/src/cli/jsonReader.py
+++ b/src/cli/jsonReader.py
@@ -1,6 +1,7 @@
 from src.cli import exceptions
 import json
 import math
+import os
 
 
 REQUIRED_SONAR_JSON_KEYS = ["paging", "baseComponent", "components"]
@@ -24,6 +25,24 @@ def file_reader(absolute_path):
     check_metrics_values(json_data)
 
     return json_data["components"]
+
+
+def folder_reader(absolute_path):
+    os.chdir(absolute_path)
+    files_in_dir = os.listdir(absolute_path)
+    components = []
+    files = []
+
+    for file_path in files_in_dir:
+        try:
+            components.append(file_reader(file_path))
+            files.append(f'{absolute_path.split("/")[-1]}/{file_path}')
+        except exceptions.MeasureSoftGramCLIException as error:
+            print("Warning: ", error, f"passing {file_path}...")
+
+    os.chdir('..')
+
+    return components, files
 
 
 def open_json_file(absolute_path):
@@ -78,7 +97,7 @@ def check_sonar_format(json_data):
 
 def check_file_extension(file_name):
     if file_name.split(".")[-1] != "json":
-        raise exceptions.InvalidMetricsJsonFile("Only JSON files are accepted")
+        raise exceptions.InvalidMetricsJsonFile("Only JSON files are accepted.")
 
 
 def raise_invalid_metric(key, metric):
@@ -104,16 +123,10 @@ def check_metrics_values(json_data):
         )
 
 
-def validate_metrics_post(response_status, response):
+def validate_metrics_post(response_status, response, file):
     if 200 <= response_status <= 299:
-        print("\nThe imported metrics were saved for the pre-configuration")
-    else:
-        print("\nThere was an ERROR while saving your Metrics\n")
+        return True, 'Data sent successfully'
 
-        if len(response) == 0:
-            return
-
-        for key, value in response.items():
-            field_name = "General" if key == "__all__" else key
-
-            print(f"\t{field_name} => {value}")
+    return \
+        False, \
+        f'FAIL: The host service server returned a {response_status} error. Trying again'

--- a/src/cli/utils.py
+++ b/src/cli/utils.py
@@ -1,4 +1,5 @@
 import pytz
+from termcolor import colored
 from datetime import datetime
 
 
@@ -37,4 +38,8 @@ def print_status_import_file(file, message):
             OK: Data sent successfully
     """
     print(f'\t\t- {file}')
-    print(f'\t\t{message}\n')
+
+    if 'OK:' in message:
+        print(colored(f'\t\t{message}\n', 'green'))
+    else:
+        print(colored(f'\t\t{message}\n', 'red'))

--- a/src/cli/utils.py
+++ b/src/cli/utils.py
@@ -12,3 +12,27 @@ def pretty_date_str(date_str, format="%m/%d/%Y %H:%M:%S", timezone="Brazil/East"
 
 def check_host_url(host_url):
     return host_url if host_url.endswith("/") else host_url + "/"
+
+
+def print_import_files(files):
+    """
+        Importing files:
+            - sonarmetrics/file1.json
+            - sonarmetrics/file2.json
+            - sonarmetrics/file3.json
+
+        Sending the file data:
+    """
+    print('\n\tImporting files:')
+
+    for file in files:
+        print(f'\t\t- {file}')
+
+
+def print_status_import_file(file, message):
+    """
+            - sonarmetrics/file1.json
+            OK: Data sent successfully
+    """
+    print(f'\t\t- {file}')
+    print(f'\t\t{message}')

--- a/src/cli/utils.py
+++ b/src/cli/utils.py
@@ -28,6 +28,8 @@ def print_import_files(files):
     for file in files:
         print(f'\t\t- {file}')
 
+    print('\n\tSending the file data:')
+
 
 def print_status_import_file(file, message):
     """
@@ -35,4 +37,4 @@ def print_status_import_file(file, message):
             OK: Data sent successfully
     """
     print(f'\t\t- {file}')
-    print(f'\t\t{message}')
+    print(f'\t\t{message}\n')

--- a/src/cli/utils.py
+++ b/src/cli/utils.py
@@ -32,12 +32,12 @@ def print_import_files(files):
     print('\n\tSending the file data:')
 
 
-def print_status_import_file(file, message):
+def print_status_import_file(file, message, trying_idx):
     """
             - sonarmetrics/file1.json
             OK: Data sent successfully
     """
-    print(f'\t\t- {file}')
+    print(f'\t\t- [{trying_idx}] {file}')
 
     if 'OK:' in message:
         print(colored(f'\t\t{message}\n', 'green'))

--- a/src/cli/utils.py
+++ b/src/cli/utils.py
@@ -8,3 +8,7 @@ def pretty_date_str(date_str, format="%m/%d/%Y %H:%M:%S", timezone="Brazil/East"
     date_time = date_time.astimezone(pytz.timezone(timezone))
 
     return date_time.strftime(format)
+
+
+def check_host_url(host_url):
+    return host_url if host_url.endswith("/") else host_url + "/"

--- a/tests/system/test_import.py
+++ b/tests/system/test_import.py
@@ -13,8 +13,8 @@ def capture(command):
 
 def test_import_metrics_file_not_found_exception_handling():
     out, _, returncode = capture(
-        ["measuresoftgram", "import", "tests/system/data/sona.json", "123", "py"]
+        ["measuresoftgram", "import", "sonarqube", "sonar-output-fake", "123", "py"]
     )
 
     assert returncode == 0
-    assert "Error:  The file was not found" in out.decode("utf-8")
+    assert "Error: The folder was not found" in out.decode("utf-8")

--- a/tests/system/test_import.py
+++ b/tests/system/test_import.py
@@ -13,7 +13,7 @@ def capture(command):
 
 def test_import_metrics_file_not_found_exception_handling():
     out, _, returncode = capture(
-        ["measuresoftgram", "import", "sonarqube", "sonar-output-fake", "123", "py"]
+        ["measuresoftgram", "import", "sonarqube", "sonar-output-fake", "py"]
     )
 
     assert returncode == 0

--- a/tests/unit/test_jsonReader.py
+++ b/tests/unit/test_jsonReader.py
@@ -12,7 +12,7 @@ def test_invalid_file_extension(file_name):
     with pytest.raises(exceptions.InvalidMetricsJsonFile) as error:
         jsonReader.check_file_extension(file_name)
 
-    assert str(error.value) == "Only JSON files are accepted"
+    assert str(error.value) == "Only JSON files are accepted."
 
 
 def test_file_reader_success():
@@ -164,48 +164,29 @@ class TestValidateMetricsPost:
     """
 
     @pytest.mark.parametrize("status_code", [200, 201, 204])
-    def test_post_success(self, status_code, mocker):
+    def test_post_success(self, status_code):
         """
         Test when a success status code is returned
         """
 
-        with mocker.patch("sys.stdout", new=StringIO()) as fake_out:
-            jsonReader.validate_metrics_post(status_code, {})
+        # with mocker.patch("sys.stdout", new=StringIO()) as fake_out:
+        message = jsonReader.validate_metrics_post(status_code)
 
-            assert (
-                "The imported metrics were saved for the pre-configuration"
-                in fake_out.getvalue()
-            )
+        assert "OK: Data sent successfully" == message
 
-    @pytest.mark.parametrize(
-        "status_code, response, additional_msg",
-        [
-            (400, {}, ""),
-            (500, {}, ""),
-            (404, {"pre_config_id": "123 is not a valid ID"}, "is not a valid ID"),
-            (
-                422,
-                {
-                    "__all__": "The metrics in this file are not the expected in the pre config. Missing metrics: a, b"
-                },
-                "The metrics in this file are not the expected in the pre config. Missing metrics: ",
-            ),
-        ],
-    )
-    def test_post_failure(self, status_code, response, additional_msg, mocker):
+    @pytest.mark.parametrize("status_code", [400, 500, 404, 422])
+    def test_post_failure(self, status_code):
         """
         Test when an error is returned
         """
 
-        with mocker.patch("sys.stdout", new=StringIO()) as fake_out:
-            jsonReader.validate_metrics_post(status_code, response)
+        # with mocker.patch("sys.stdout", new=StringIO()) as fake_out:
+        message = jsonReader.validate_metrics_post(status_code)
 
-            output = fake_out.getvalue()
-
-            assert "There was an ERROR while saving your Metrics" in output
-
-            if additional_msg:
-                assert additional_msg in output
+        assert (
+            f'FAIL: The host service server returned a {status_code} error. Trying again'
+            == message
+        )
 
 
 class TestCheckMetricsValues:

--- a/tests/unit/test_jsonReader.py
+++ b/tests/unit/test_jsonReader.py
@@ -1,6 +1,6 @@
 import pytest
-from io import StringIO
 from src.cli import jsonReader, exceptions
+# from io import StringIO
 
 
 @pytest.mark.parametrize("file_name", ["sonar.txt", "sonar.xml", "sonar.jjson"])

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps =
     pytest-cov
     pytest-mock
     termcolor
+    coverage
     -r requirements.txt
 
 setenv =
@@ -19,3 +20,7 @@ setenv =
 
 commands =
     pytest {posargs}
+    coverage erase
+    coverage run setup.py test
+    coverage report --omit='.tox/*,*/test*'
+    coverage html --omit='.tox/*,*/test*'

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,8 @@ deps =
     pytz
     pytest-cov
     pytest-mock
-    -rrequirements.txt
+    termcolor
+    -r requirements.txt
 
 setenv =
     PYTHONPATH=.


### PR DESCRIPTION
## Descrição
Implementação do comando `import sonarqube <DIR>` do CLI measuresoftgram.

Issue [#152 Criar comando na CLI para importar métricas de um ou mais arquivo do SonarQube](https://github.com/fga-eps-mds/2022-1-MeasureSoftGram-Doc/issues/152)

Esse comando visa salvar os dados na API do serviço `service`.

Por meio deste comando é possível:

- Importar um diretório com arquivos de output do sonarqube, por meio do comando `import sonarqube`.
- Especificar o local onde está hospedado a instância do serviço `service`, sendo por padrão a instância hospedada no heroku, por meio do parâmetro **`--host`**
* Especificar o projeto que essa entidade (medida ou métrica) pertence por meio do parâmetro **`--repository_id`**. Caso o valor não seja passado é procurado o valor na variável de ambiente **`MSG_ORGANIZATION_ID`**, e caso ela não exista é usado o valor **1**.
* Especificar a organização que esse projeto pertence por meio do parâmetro **`--organization_id`**. Caso o valor não seja passado é procurado o valor na variável de ambiente **`MSG_REPOSITORY_ID`**, e caso ela não exista é usado o valor **1**.

## Vídeo do uso do comando e suas funcionalidades

https://youtu.be/nlQUNfBRwtI

## Porque este Pull Request é necessário?
Uma das funcionalidades requisitadas pelo cliente é a utilização do CLI para obter dados de mais de um arquivo de output do **sonarqube**. Dessa forma, por meio do CLI será possível importar um diretório de arquivos de output. Esse PR implementa a imoportação de um diretório de arquivos so sonarqube.

## Critérios de aceitação

1. [x] Importar um diretório de arquivos, ignorando os que não sejam no formato json.
2. [x] Indicar ao usuário de uma forma adequada o status de importação dos arquivos.
3. [x] Especificar a instância do serviço `service`
4. [x] Especificar o repositório no sistema do MeasureSoftGram
5. [x] Especificar a organização no sistema do MeasureSoftGram
6. [x] Passar nos testes 

Closes #152
