### PR TITLE
#249 - Validar a passagem de parâmetros para get e import no CLI

### DIFF
--- a/src/cli/cliRunner.py
+++ b/src/cli/cliRunner.py
@@ -23,11 +23,15 @@ def setup():
 
     subparsers = parser.add_subparsers(dest="command", help="sub-command help")
 
-    parser_import = subparsers.add_parser("import", help="Import a folder with metrics")
+    parser_import = subparsers.add_parser(
+        "import",
+        help="Import a folder with metrics"
+    )
 
     parser_import.add_argument(
         "output_origin",
         type=str,
+        choices=(AVAILABLE_IMPORTS),
         help=(
             "Import a metrics files from some origin. Valid values are: "
             + ", ".join(AVAILABLE_IMPORTS)
@@ -76,12 +80,12 @@ def setup():
 
     parser_get_entity = subparsers.add_parser(
         "get",
-        help="Gets the last record of a specific entity",
     )
 
     parser_get_entity.add_argument(
         "entity",
         type=str,
+        choices=(AVAILABLE_ENTITIES),
         help=(
             "The entity to get. Valid values are: "
             + ", ".join(AVAILABLE_ENTITIES)

--- a/src/cli/cliRunner.py
+++ b/src/cli/cliRunner.py
@@ -18,6 +18,9 @@ def setup():
     parser = argparse.ArgumentParser(
         description="Command line interface for measuresoftgram"
     )
+
+    argparse.ArgumentTypeError('invalid value!!!')
+
     subparsers = parser.add_subparsers(dest="command", help="sub-command help")
 
     parser_import = subparsers.add_parser("import", help="Import a folder with metrics")

--- a/src/cli/commands/parse_get_entity/parse_get_entity.py
+++ b/src/cli/commands/parse_get_entity/parse_get_entity.py
@@ -35,11 +35,11 @@ def parse_get_entity(
     )
     response = ServiceClient.get_entity(host_url)
 
-    if response.ok is False:
-        print(
-            f"An error occurred while getting the {entity_name} with the ID {entity_id}. The parameter appears not to be valid. Use the valid parameters {AVAILABLE_ENTITIES}."
-        )
-        return
+    # if response.ok is False:
+    #     print(
+    #         f"An error occurred while getting the {entity_name} with the ID {entity_id}. The parameter appears not to be valid. Use the valid parameters {AVAILABLE_ENTITIES}."
+    #     )
+    #     return
 
     extracted_data, headers, data = get_entity(
         response,

--- a/src/cli/commands/parse_get_entity/parse_get_entity.py
+++ b/src/cli/commands/parse_get_entity/parse_get_entity.py
@@ -5,7 +5,7 @@ from src.cli.commands.parse_get_entity.utils import get_entity
 
 from src.cli.utils import check_host_url
 from src.clients.service_client import ServiceClient
-from src.config.settings import SUPPORTED_FORMATS
+from src.config.settings import SUPPORTED_FORMATS, AVAILABLE_ENTITIES
 
 
 def parse_get_entity(
@@ -37,7 +37,7 @@ def parse_get_entity(
 
     if response.ok is False:
         print(
-            f"There was an error while getting the {entity_name} with id {entity_id}."
+            f"An error occurred while getting the {entity_name} with the ID {entity_id}. The parameter appears not to be valid. Use the valid parameters {AVAILABLE_ENTITIES}."
         )
         return
 

--- a/src/cli/commands/parse_get_entity/parse_get_entity.py
+++ b/src/cli/commands/parse_get_entity/parse_get_entity.py
@@ -5,7 +5,7 @@ from src.cli.commands.parse_get_entity.utils import get_entity
 
 from src.cli.utils import check_host_url
 from src.clients.service_client import ServiceClient
-from src.config.settings import SUPPORTED_FORMATS, AVAILABLE_ENTITIES
+from src.config.settings import SUPPORTED_FORMATS
 
 
 def parse_get_entity(
@@ -34,12 +34,6 @@ def parse_get_entity(
         f'{entity_id if entity_id else ""}'
     )
     response = ServiceClient.get_entity(host_url)
-
-    # if response.ok is False:
-    #     print(
-    #         f"An error occurred while getting the {entity_name} with the ID {entity_id}. The parameter appears not to be valid. Use the valid parameters {AVAILABLE_ENTITIES}."
-    #     )
-    #     return
 
     extracted_data, headers, data = get_entity(
         response,


### PR DESCRIPTION
# Validar a passagem de parâmetros para get e import no CLI

## Descrição

Realizar a validação da passagem de parâmetros passados pelo usuário para as funcionalidade get e import na CLI

[#249 - Validar a passagem de parâmetros para get e import](https://github.com/fga-eps-mds/2022-1-MeasureSoftGram-Doc/issues/249)

## Porque este Pull Request é necessário?
Quando passado um parâmetro invalido pelo usuário é necessário indicar o erro da melhor forma e como utilizar os parâmetros corretos.

## Critérios de aceitação

1. [x] A funcionalidade de get e import continuarem funcionando
2. [x] Indicar para o usuário o erro ao utilizar parâmetros inválidos do comando "get" e informar parâmetros válidos
3. [x] Indicar para o usuário o erro ao utilizar parâmetros inválidos do comando "import" e informar parâmetros válidos

Closes #249
