### PR TITLE
Criar arquivo de inicialização

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ setup(
         "requests==2.28.1",
         "pytz",
         "tabulate==0.8.10",
-        "termcolor==1.1.0"
+        "termcolor==1.1.0",
+        "validators==0.20.0"
     ],
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow

--- a/src/cli/cliRunner.py
+++ b/src/cli/cliRunner.py
@@ -26,7 +26,7 @@ def setup():
 
     parser_init = subparsers.add_parser(
         "init",
-        help="Create a init file `.measuresoftgram.json` with your default organization, product and repositories"
+        help="Create a init file `.measuresoftgram` with your default organization, product and repositories"
     )
 
     parser_init.add_argument(

--- a/src/cli/cliRunner.py
+++ b/src/cli/cliRunner.py
@@ -4,7 +4,7 @@ import sys
 import signal
 from pathlib import Path
 
-from src.cli.commands import parse_import, parse_get_entity
+from src.cli.commands import parse_import, parse_get_entity, parse_init
 
 from src.config.settings import AVAILABLE_ENTITIES, AVAILABLE_IMPORTS, SUPPORTED_FORMATS
 
@@ -22,6 +22,28 @@ def setup():
     argparse.ArgumentTypeError('invalid value!!!')
 
     subparsers = parser.add_subparsers(dest="command", help="sub-command help")
+
+    parser_init = subparsers.add_parser(
+        "init",
+        help="Create a init file `.measuresoftgram.json` with your default organization, product and repositories"
+    )
+
+    parser_init.add_argument(
+        "file_path",
+        type=lambda p: Path(p).absolute(),
+        help="Path to your configured JSON file with the organization, product and repositories names",
+    )
+
+    parser_init.add_argument(
+        "--host",
+        type=str,
+        nargs='?',
+        default=os.getenv(
+            "MSG_SERVICE_HOST",
+            "https://measuresoftgram-service.herokuapp.com/"
+        ),
+        help="The host of the service",
+    )
 
     parser_import = subparsers.add_parser(
         "import",
@@ -226,6 +248,12 @@ def setup():
             args.organization_id,
             args.repository_id,
             args.product_id,
+        )
+
+    elif args.command == "init":
+        parse_init(
+            args.file_path,
+            args.host,
         )
 
     # elif args.command == "create":

--- a/src/cli/commands/__init__.py
+++ b/src/cli/commands/__init__.py
@@ -8,6 +8,7 @@ from src.cli.commands.parse_get_entity.parse_get_entity import parse_get_entity
 from src.cli.commands.parse_available.parse_available import parse_available
 from src.cli.commands.parse_show.parse_show import parse_show
 from src.cli.commands.parse_list.parse_list import parse_list
+from src.cli.commands.parse_init.parse_init import parse_init
 
 from src.cli.commands.parse_create.utils import (
     check_file_extension,

--- a/src/cli/commands/parse_get_entity/utils.py
+++ b/src/cli/commands/parse_get_entity/utils.py
@@ -5,6 +5,7 @@ entities_keys = {
     'subcharacteristics': 'subcharacteristic_id',
 }
 
+
 def get_entity(response, entity_name, entity_id, history):
     if entity_id:
         extracted_data, headers, data = \

--- a/src/cli/commands/parse_init/parse_init.py
+++ b/src/cli/commands/parse_init/parse_init.py
@@ -28,7 +28,7 @@ def parse_init(file_path, host_url):
         with open('.measuresoftgram', 'w') as file:
             file.write(json.dumps(init_data, indent=4))
 
-        print(colored("'.measuresoftgram' init file created with success ...", "green"))
+        print(colored("'.measuresoftgram' init file created with success", "green"))
     except MeasureSoftGramCLIException as error:
         print(colored(f"Error: {error}", "red"))
         return 1

--- a/src/cli/commands/parse_init/parse_init.py
+++ b/src/cli/commands/parse_init/parse_init.py
@@ -1,5 +1,7 @@
 import json
 
+from termcolor import colored
+
 from src.cli.jsonReader import check_file_extension, open_json_file
 from src.cli.commands.parse_init.utils import (
     check_if_init_file_already_exists,
@@ -22,8 +24,11 @@ def parse_init(file_path, host_url):
         validate_user_file(user_config_file)
 
         init_data = create_org_prod_n_repos(host_url, user_config_file)
-        with open('.measuresoftgram.json', 'w') as f:
-            f.write(json.dumps(init_data, indent=4))
+
+        with open('.measuresoftgram', 'w') as file:
+            file.write(json.dumps(init_data, indent=4))
+
+        print(colored("Init file created with success ...", "green"))
     except MeasureSoftGramCLIException as error:
-        print("Error:", error)
-        return
+        print(colored(f"Error: {error}", "red"))
+        return 1

--- a/src/cli/commands/parse_init/parse_init.py
+++ b/src/cli/commands/parse_init/parse_init.py
@@ -1,0 +1,20 @@
+from src.cli.jsonReader import check_file_extension, open_json_file
+from src.cli.commands.parse_init.utils import check_if_init_file_already_exists, validate_user_file
+from src.cli.exceptions import MeasureSoftGramCLIException
+from src.cli.utils import check_host_url
+
+
+def parse_init(file_path, host_url):
+    file_path = str(file_path)
+
+    try:
+        check_if_init_file_already_exists()
+        check_file_extension(file_path)
+
+        user_config_file = open_json_file(file_path)
+        validate_user_file(user_config_file)
+    except MeasureSoftGramCLIException as error:
+        print("Error:", error)
+        return
+
+    host_url = check_host_url(host_url)

--- a/src/cli/commands/parse_init/parse_init.py
+++ b/src/cli/commands/parse_init/parse_init.py
@@ -1,11 +1,18 @@
+import json
+
 from src.cli.jsonReader import check_file_extension, open_json_file
-from src.cli.commands.parse_init.utils import check_if_init_file_already_exists, validate_user_file
+from src.cli.commands.parse_init.utils import (
+    check_if_init_file_already_exists,
+    validate_user_file,
+    create_org_prod_n_repos
+)
 from src.cli.exceptions import MeasureSoftGramCLIException
 from src.cli.utils import check_host_url
 
 
 def parse_init(file_path, host_url):
     file_path = str(file_path)
+    host_url = check_host_url(host_url)
 
     try:
         check_if_init_file_already_exists()
@@ -13,8 +20,10 @@ def parse_init(file_path, host_url):
 
         user_config_file = open_json_file(file_path)
         validate_user_file(user_config_file)
+
+        init_data = create_org_prod_n_repos(host_url, user_config_file)
+        with open('.measuresoftgram.json', 'w') as f:
+            f.write(json.dumps(init_data, indent=4))
     except MeasureSoftGramCLIException as error:
         print("Error:", error)
         return
-
-    host_url = check_host_url(host_url)

--- a/src/cli/commands/parse_init/parse_init.py
+++ b/src/cli/commands/parse_init/parse_init.py
@@ -28,7 +28,7 @@ def parse_init(file_path, host_url):
         with open('.measuresoftgram', 'w') as file:
             file.write(json.dumps(init_data, indent=4))
 
-        print(colored("Init file created with success ...", "green"))
+        print(colored("'.measuresoftgram' init file created with success ...", "green"))
     except MeasureSoftGramCLIException as error:
         print(colored(f"Error: {error}", "red"))
         return 1

--- a/src/cli/commands/parse_init/utils.py
+++ b/src/cli/commands/parse_init/utils.py
@@ -6,12 +6,14 @@ import validators
 from src.cli.exceptions import exceptions
 from src.clients.service_client import ServiceClient
 
-INIT_FILE_NAME = ".measuresoftgram.json"
+INIT_FILE_NAME = ".measuresoftgram"
 
 
 def check_if_init_file_already_exists():
     if exists(INIT_FILE_NAME):
-        raise exceptions.InitFileAlreadyExists("Init file already exists. Check the file '.measuresoftgram.json'")
+        raise exceptions.InitFileAlreadyExists(
+            "Init file already exists. Check the file '.measuresoftgram'"
+        )
 
 
 def validate_user_file(config_json_file):

--- a/src/cli/commands/parse_init/utils.py
+++ b/src/cli/commands/parse_init/utils.py
@@ -91,6 +91,11 @@ def create_entity(url, name, entity):
 
     if response.status_code == 201:
         return json.loads(response.text)["id"]
+    elif response.status_code == 400:
+        raise exceptions.MeasureSoftGramCLIException(
+            f"An {entity} with the provided name already exists. "
+            f"Use a new one or change the '.measuresoftgram' file manually."
+        )
     else:
         raise exceptions.MeasureSoftGramCLIException(
             f"Unable to create an {entity}. Check the connection to the Service host."

--- a/src/cli/commands/parse_init/utils.py
+++ b/src/cli/commands/parse_init/utils.py
@@ -2,6 +2,7 @@ import json
 from os.path import exists
 
 import validators
+from termcolor import colored
 
 from src.cli.exceptions import exceptions
 from src.clients.service_client import ServiceClient
@@ -90,7 +91,9 @@ def create_entity(url, name, entity):
     response = ServiceClient.make_post_request(url, payload)
 
     if response.status_code == 201:
-        return json.loads(response.text)["id"]
+        entity_id = json.loads(response.text)["id"]
+        print(colored(f"\tCreated {entity} with name {name} and id {entity_id} ...", "blue"))
+        return entity_id
     elif response.status_code == 400:
         raise exceptions.MeasureSoftGramCLIException(
             f"An {entity} with the provided name already exists. "

--- a/src/cli/commands/parse_init/utils.py
+++ b/src/cli/commands/parse_init/utils.py
@@ -1,0 +1,52 @@
+from os.path import exists
+
+import validators
+
+from src.cli.exceptions import exceptions
+
+INIT_FILE_NAME = ".measuresoftgram.json"
+
+
+def check_if_init_file_already_exists():
+    if exists(INIT_FILE_NAME):
+        raise exceptions.InitFileAlreadyExists("Init file already exists. Check the file '.measuresoftgram.json'")
+
+
+def validate_user_file(config_json_file):
+    check_file_keys(config_json_file)
+    check_file_data(config_json_file)
+
+
+def check_file_keys(json_file):
+    file_keys_diff = {"organization_name", "product_name", "repositories"} - json_file.keys()
+    if len(file_keys_diff) > 0:
+        raise exceptions.InvalidMeasuresoftgramFormat(
+            f"Provided file is missing the required keys: {', '.join(file_keys_diff)}."
+        )
+
+
+def check_file_data(json_file):
+    organization = json_file["organization_name"]
+    product = json_file["product_name"]
+    repositories = json_file["repositories"]
+
+    if not isinstance(organization, str) or not organization.strip():
+        raise exceptions.InvalidMeasuresoftgramFormat(
+            "Organization name must be a not empty string."
+        )
+
+    if not isinstance(product, str) or not product.strip():
+        raise exceptions.InvalidMeasuresoftgramFormat(
+            "Product name must be a not empty string."
+        )
+
+    if not isinstance(repositories, list):
+        raise exceptions.InvalidMeasuresoftgramFormat(
+            "Repositories must be a list of urls."
+        )
+
+    for repository in repositories:
+        if validators.url(repository) is not True:
+            raise exceptions.InvalidMeasuresoftgramFormat(
+                f"Invalid url format for repository: {repository}"
+            )

--- a/src/cli/exceptions/exceptions.py
+++ b/src/cli/exceptions/exceptions.py
@@ -34,6 +34,12 @@ class UnableToReadFile(MeasureSoftGramCLIException):
     pass
 
 
+class InitFileAlreadyExists(MeasureSoftGramCLIException):
+    """Raised when the init file already exists"""
+
+    pass
+
+
 class InvalidWeight(MeasureSoftGramCLIException):
     """Raised when a invalid weight is provided to the MeasureSoftGram"""
 

--- a/tests/unit/data/init.json
+++ b/tests/unit/data/init.json
@@ -1,0 +1,10 @@
+{
+  "organization_name": "fga-eps-mds",
+  "product_name": "MeasureSoftGram",
+  "repositories": [
+    "https://github.com/fga-eps-mds/2022-1-MeasureSoftGram-CLI",
+    "https://github.com/fga-eps-mds/2022-1-MeasureSoftGram-Core",
+    "https://github.com/fga-eps-mds/2022-1-MeasureSoftGram-Front",
+    "https://github.com/fga-eps-mds/2022-1-MeasureSoftGram-Service"
+  ]
+}

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -58,7 +58,7 @@ def test_init_create_file(mocker):
         parse_init("tests/unit/data/init.json", DUMMY_HOST)
 
         assert EXPECTED_INIT_DATA == read_json(".measuresoftgram")
-        assert "'.measuresoftgram' init file created with success ..." in fake_out.getvalue()
+        assert "'.measuresoftgram' init file created with success" in fake_out.getvalue()
         assert os.path.exists(".measuresoftgram")
 
 

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -1,0 +1,102 @@
+import os
+import copy
+import json
+from io import StringIO
+
+import pytest
+
+from src.cli.commands import parse_init
+from tests.test_helpers import read_json
+from src.cli.exceptions import exceptions
+from src.cli.commands.parse_init.utils import validate_user_file
+
+DUMMY_HOST = "http://dummy_host.com/"
+EXPECTED_INIT_DATA = {
+    "organization": {
+        "name": "fga-eps-mds",
+        "id": 1
+    },
+    "product": {
+        "name": "MeasureSoftGram",
+        "id": 1
+    },
+    "repositories": [
+        {"2022-1-MeasureSoftGram-CLI": 1},
+        {"2022-1-MeasureSoftGram-Core": 1},
+        {"2022-1-MeasureSoftGram-Front": 1},
+        {"2022-1-MeasureSoftGram-Service": 1}
+    ]
+}
+
+
+class DummyResponse:
+    def __init__(self, status_code, mocked_data):
+        self.status_code = status_code
+        self.text = json.dumps(mocked_data)
+
+
+def setup():
+    try:
+        os.remove(".measuresoftgram")
+    except OSError:
+        pass
+
+
+def teardown():
+    try:
+        os.remove(".measuresoftgram")
+    except OSError:
+        pass
+
+
+def test_init_create_file(mocker):
+    mocker.patch(
+        "src.clients.service_client.ServiceClient.make_post_request",
+        return_value=DummyResponse(201, {"id": 1})
+    )
+    with mocker.patch("sys.stdout", new=StringIO()) as fake_out:
+        parse_init("tests/unit/data/init.json", DUMMY_HOST)
+
+        assert EXPECTED_INIT_DATA == read_json(".measuresoftgram")
+        assert "Init file created with success ..." in fake_out.getvalue()
+        assert os.path.exists(".measuresoftgram")
+
+
+def test_init_file_already_exists(mocker):
+    with mocker.patch("sys.stdout", new=StringIO()) as fake_out:
+        with open('.measuresoftgram', 'w') as file:
+            file.write(json.dumps(EXPECTED_INIT_DATA, indent=4))
+
+        return_code = parse_init("tests/unit/data/init.json", DUMMY_HOST)
+
+        assert return_code == 1
+        assert "Error: Init file already exists. Check the file '.measuresoftgram'" in fake_out.getvalue()
+
+
+def test_user_init_invalid_file():
+    user_init_file_data = read_json("tests/unit/data/init.json")
+
+    with pytest.raises(exceptions.InvalidMeasuresoftgramFormat):
+        invalid_data = copy.deepcopy(user_init_file_data)
+        invalid_data.pop("organization_name")
+        validate_user_file(invalid_data)
+
+    with pytest.raises(exceptions.InvalidMeasuresoftgramFormat):
+        invalid_data = copy.deepcopy(user_init_file_data)
+        invalid_data["organization_name"] = ""
+        validate_user_file(invalid_data)
+
+    with pytest.raises(exceptions.InvalidMeasuresoftgramFormat):
+        invalid_data = copy.deepcopy(user_init_file_data)
+        invalid_data["product_name"] = ""
+        validate_user_file(invalid_data)
+
+    with pytest.raises(exceptions.InvalidMeasuresoftgramFormat):
+        invalid_data = copy.deepcopy(user_init_file_data)
+        invalid_data["repositories"] = "Repositórios"
+        validate_user_file(invalid_data)
+
+    with pytest.raises(exceptions.InvalidMeasuresoftgramFormat):
+        invalid_data = copy.deepcopy(user_init_file_data)
+        invalid_data["repositories"][0] = "invalid_url/com"
+        validate_user_file(invalid_data)

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -58,7 +58,7 @@ def test_init_create_file(mocker):
         parse_init("tests/unit/data/init.json", DUMMY_HOST)
 
         assert EXPECTED_INIT_DATA == read_json(".measuresoftgram")
-        assert "Init file created with success ..." in fake_out.getvalue()
+        assert "'.measuresoftgram' init file created with success ..." in fake_out.getvalue()
         assert os.path.exists(".measuresoftgram")
 
 


### PR DESCRIPTION
## Descrição
Este pull request tem como objetivo adicionar um comando (***init***) que possibilite criar um arquivo de inicialização com organização, produto e repositórios a partir de um arquivo apontado pelo usuário 

Closes #[284](https://github.com/fga-eps-mds/2022-1-MeasureSoftGram-Doc/issues/284)

## Como Testar:

- O manual de uso do comando init pode ser acessado em: https://fga-eps-mds.github.io/2022-1-MeasureSoftGram-Doc/#/manuais/CLI/init

- Rodar o comando `measuresoftgram init file_path`  em que `file_path`é o caminho para um arquivo com o formato:

```json
{
"organization_name": "fga-eps-mds",
"product_name": "MeasureSoftGram",
"repositories": [
   "https://github.com/fga-eps-mds/2022-1-MeasureSoftGram-CLI",
   "https://github.com/fga-eps-mds/2022-1-MeasureSoftGram-Service",
   "https://github.com/fga-eps-mds/2022-1-MeasureSoftGram-Front",
   "https://github.com/fga-eps-mds/2022-1-MeasureSoftGram-Core"
]
}
```

- Caso o comando rode com sucesso, é esperado que seja criado um arquivo `.measuresoftgram` com o formato:
```json
{
    "organization": {
        "name": "fga-eps-mds",
        "id": 1
    },
    "product": {
        "name": "MeasureSoftGram",
        "id": 1
    },
    "repositories": [
      {
        "2022-1-MeasureSoftGram-CLI": 1
      },
      {
        "2022-1-MeasureSoftGram-Core": 2
      },
      {
        "2022-1-MeasureSoftGram-Service": 3
      },
      {
        "2022-1-MeasureSoftGram-Front": 4
      }
    ]
}
```

## Critérios de aceitação
- [ ] A execução do comando `measuresoftgram init` deve consumir um arquivo que será criado pelo usuário.
- [ ] Deve se criado as entidades (organização, produto e repositório) no sistema do measuresoftgram
- [ ] Após a execução do comando init deve ser gerado um arquivo com o nome `.measuresoftgram` especificando os IDs no sistema do measuresoftgramb
- [ ] Se o arquivo `.measuresoftgram` já existir no diretório onde é execudado o comando init, o comando deve abortar e avisar o usuário que esse repositório já foi iniciado.
