### PR TITLE
283 get sqc current value and history

### DIFF
--- a/src/cli/commands/parse_get_entity/parse_get_entity.py
+++ b/src/cli/commands/parse_get_entity/parse_get_entity.py
@@ -18,6 +18,37 @@ def parse_get_entity(
     output_format,
     history,
 ):
+    if entity_name == 'sqc':
+        print("     oioi")
+        host_url = check_host_url(host_url)
+        host_url += (
+        'api/v1/'
+        f'organizations/{organization_id}/'
+        f'products/{product_id}/'
+        f'repositories/{repository_id}/'
+        f'{"historical-values/" if history else "latest-values/"}'
+        f'sqc/'
+        f'{entity_id if entity_id else ""}'
+
+        # http://measuresoftgram-service.herokuapp.com/api/v1/organizations/1/products/3/repositories/6/latest-values/sqc/
+
+        )
+        response = ServiceClient.get_entity(host_url)
+
+        extracted_data, headers, data = get_entity(
+            response,
+            entity_id,
+            history
+        )
+
+        if output_format == 'tabular':
+            print(tabulate(extracted_data, headers=headers))
+        elif output_format == 'json':
+            print(json.dumps(data))
+
+
+        return
+
     if output_format not in SUPPORTED_FORMATS:
         print((
             "Output format not supported. "

--- a/src/cli/commands/parse_get_entity/parse_get_entity.py
+++ b/src/cli/commands/parse_get_entity/parse_get_entity.py
@@ -22,21 +22,17 @@ def parse_get_entity(
         print("     oioi")
         host_url = check_host_url(host_url)
         host_url += (
-        'api/v1/'
-        f'organizations/{organization_id}/'
-        f'products/{product_id}/'
-        f'repositories/{repository_id}/'
-        f'{"historical-values/" if history else "latest-values/"}'
-        f'sqc/'
-        f'{entity_id if entity_id else ""}'
-
-        # http://measuresoftgram-service.herokuapp.com/api/v1/organizations/1/products/3/repositories/6/latest-values/sqc/
-
+            'api/v1/'
+            f'organizations/{organization_id}/'
+            f'products/{product_id}/'
+            f'repositories-sqc-historical-values/' if history else 'repositories-sqc-latest-values/'
         )
+
         response = ServiceClient.get_entity(host_url)
 
         extracted_data, headers, data = get_entity(
             response,
+            entity_name,
             entity_id,
             history
         )
@@ -45,7 +41,6 @@ def parse_get_entity(
             print(tabulate(extracted_data, headers=headers))
         elif output_format == 'json':
             print(json.dumps(data))
-
 
         return
 

--- a/src/cli/commands/parse_get_entity/parse_get_entity.py
+++ b/src/cli/commands/parse_get_entity/parse_get_entity.py
@@ -1,12 +1,57 @@
 import json
 
 from tabulate import tabulate
-from src.cli.commands.parse_get_entity.utils import get_entity
+from src.cli.commands.parse_get_entity import utils
 
 from src.cli.utils import check_host_url
 from src.clients.service_client import ServiceClient
 from src.config.settings import SUPPORTED_FORMATS
 
+
+def get_sqc(response, entity_id, history):
+    if entity_id:
+        extracted_data, headers, data = \
+            utils.get_entity_id(response, 'sqc', history)
+    else:
+        extracted_data, headers, data = \
+            utils.get_without_entity_id(response, 'sqc', history)
+
+    return extracted_data, headers, data
+
+
+def parse_get_sqc(
+    repository_id,
+    host_url,
+    organization_id,
+    product_id,
+    output_format,
+    history,
+):
+    host_url = check_host_url(host_url)
+    host_url += (
+        f'api/v1/organizations/{organization_id}/products/{product_id}/'
+    )
+
+    if history:
+        host_url += 'repositories-sqc-historical-values/'
+    else:
+        host_url += 'repositories-sqc-latest-values/'
+
+    # /api/v1/organizations/1/products/3/repositories/6/latest-values/sqc/
+    response = ServiceClient.make_get_request(host_url)
+
+    extracted_data, headers, data = get_sqc(
+        response,
+        repository_id,
+        history,
+    )
+
+    if output_format == 'tabular':
+        print(tabulate(extracted_data, headers=headers))
+    elif output_format == 'json':
+        print(json.dumps(data))
+
+    return
 
 def parse_get_entity(
     entity_name,
@@ -19,30 +64,12 @@ def parse_get_entity(
     history,
 ):
     if entity_name == 'sqc':
-        print("     oioi")
-        host_url = check_host_url(host_url)
-        host_url += (
-            'api/v1/'
-            f'organizations/{organization_id}/'
-            f'products/{product_id}/'
-            f'repositories-sqc-historical-values/' if history else 'repositories-sqc-latest-values/'
-        )
-
-        response = ServiceClient.get_entity(host_url)
-
-        extracted_data, headers, data = get_entity(
-            response,
-            entity_name,
-            entity_id,
-            history
-        )
-
-        if output_format == 'tabular':
-            print(tabulate(extracted_data, headers=headers))
-        elif output_format == 'json':
-            print(json.dumps(data))
-
-        return
+        parse_get_sqc(entity_id,
+                        host_url,
+                        organization_id,
+                        product_id,
+                        output_format,
+                        history)
 
     if output_format not in SUPPORTED_FORMATS:
         print((
@@ -63,7 +90,7 @@ def parse_get_entity(
     )
     response = ServiceClient.get_entity(host_url)
 
-    extracted_data, headers, data = get_entity(
+    extracted_data, headers, data = utils.get_entity(
         response,
         entity_name,
         entity_id,
@@ -74,3 +101,15 @@ def parse_get_entity(
         print(tabulate(extracted_data, headers=headers))
     elif output_format == 'json':
         print(json.dumps(data))
+
+if __name__ == '__main__':
+    parse_get_entity(
+        entity_name = 'sqc',
+        entity_id = None,
+        host_url='https://measuresoftgram-service.herokuapp.com/',
+        organization_id = 1,
+        repository_id = 6,
+        product_id = 3,
+        output_format = 'tabular',
+        history = False,
+)

--- a/src/cli/commands/parse_get_entity/utils.py
+++ b/src/cli/commands/parse_get_entity/utils.py
@@ -3,6 +3,7 @@ entities_keys = {
     'measures': 'measure_id',
     'characteristics': 'characteristic_id',
     'subcharacteristics': 'subcharacteristic_id',
+    'sqc' : ''
 }
 
 def get_entity(response, entity_name, entity_id, history):
@@ -12,6 +13,16 @@ def get_entity(response, entity_name, entity_id, history):
     else:
         extracted_data, headers, data = \
             get_without_entity_id(response, entity_name, history)
+
+    return extracted_data, headers, data
+
+def get_sqc(response, entity_id, history):
+    if entity_id:
+        extracted_data, headers, data = \
+            get_entity_id(response, history)
+    else:
+        extracted_data, headers, data = \
+            get_without_entity_id(response, history)
 
     return extracted_data, headers, data
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -9,7 +9,7 @@ AVAILABLE_ENTITIES = [
     "measures",
     "subcharacteristics",
     "characteristics",
-    # "sqc",
+    "sqc",
 ]
 
 SUPPORTED_FORMATS = [


### PR DESCRIPTION
## Descrição
Atualmente, não é possível obter o valor atual do SQC, nem o histórico, via CLI. É desejável que essa função exista para que possamos usá-la dentro da CLI.

## Critérios de aceitação

- [ ] A execução do comando `get entity sqc` deve retornar o valor atual do SQC;
- [ ] A execução do comando `get entity sqc --history` deve retornar todo o histórico de valores do SQC.
